### PR TITLE
Fix publish GitHub Action condition

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - run: ninja -k 0 # Run ninja again to make sure there's nothing to do
 
   publish:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'pull_request'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     name: Publish
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
I think we should be running this on `push`es to `main` instead of `pull_request`s to `main`.