### PR TITLE
Add github username/email in Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,5 +51,7 @@ jobs:
       - run: ninja -k 0
       - run: |
           git add dist --force
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "github-action"
           git commit --amend -C HEAD
           git push origin


### PR DESCRIPTION
This should fix the latest issue:

```
Committer identity unknown
*** Please tell me who you are.
Run
  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"
to set your account's default identity.
```