### PR TITLE
Move setting git username/email higher up

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,8 @@ jobs:
           cache: 'npm'
       - uses: seanmiddleditch/gha-setup-ninja@master
       - run: |
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "github-action"
           git fetch origin main:main --depth 1
           git merge origin/main --message "Generate files" --log=1 --allow-unrelated-histories --strategy-option theirs
       - run: npm ci


### PR DESCRIPTION
This needs to be done before the `git merge` to avoid error messages.