### PR TITLE
Add platform to cache key

### DIFF
--- a/src/common.mts
+++ b/src/common.mts
@@ -1,3 +1,5 @@
 import { join } from "node:path";
 
 export const archive = join("trimja-cache", "ninjafiles.tar.gz");
+
+export const cachePrefix = `TRIMJA-${process.platform}-`;

--- a/src/main.m.mts
+++ b/src/main.m.mts
@@ -6,7 +6,7 @@ import { promisify } from "node:util";
 import { join } from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { appendFile, writeFile } from "node:fs/promises";
-import { archive } from "./common.mjs";
+import { archive, cachePrefix } from "./common.mjs";
 const execFile = promisify(execFileCallback);
 
 function getPlatformVars(version: string): {
@@ -77,7 +77,9 @@ try {
     });
 
     info("Getting affected files");
-    const matchedCache = await restoreCache([archive], "TRIMJA-", ["TRIMJA-"]);
+    const matchedCache = await restoreCache([archive], cachePrefix, [
+      cachePrefix,
+    ]);
     if (matchedCache === undefined) {
       info("No cache found, skipping trimja");
       return;
@@ -85,7 +87,7 @@ try {
 
     info("Extracting ninja files");
     await extractTar(archive, builddir);
-    const hash = matchedCache.slice("TRIMJA-".length);
+    const hash = matchedCache.slice(cachePrefix.length);
 
     info(`Attempting to fetch ${hash}...`);
     try {

--- a/src/post.m.mts
+++ b/src/post.m.mts
@@ -4,7 +4,7 @@ import { exec } from "@actions/exec";
 import { join } from "node:path";
 import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
-import { archive } from "./common.mjs";
+import { archive, cachePrefix } from "./common.mjs";
 
 try {
   (async () => {
@@ -27,7 +27,7 @@ try {
     info(`Creating ${archive}`);
     await exec("tar", ["-czvf", archive, "-C", builddir, ...files]);
 
-    const key = `TRIMJA-${HASH}`;
+    const key = `${cachePrefix}${HASH}`;
     info(`Saving cache '${key}'`);
     await saveCache([archive], key);
   })();


### PR DESCRIPTION
Even though caches are not shared across platforms by default, it seems that they may not be namespaced as we are getting warnings that keys already exist.