### PR TITLE
Remove CTest from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,7 @@ jobs:
     # Step 5: Build only those things affected by the latest commits
     - run: cmake --build output --config Debug
 
-    # Step 6: Run any affected tests with CTest
-    - run: ctest --build-config Debug --output-on-failure --test-dir output
-
-    # Step 7: Run legacy tests that haven't been migrated to CTest
+    # Step 6: Run legacy tests that aren't yet in Ninja
     - run: ./output/extra-tests --run-all-tests
 ```
 


### PR DESCRIPTION
CTest doesn't always output the correct dependencies to Ninja so remove this as an example.