### PR TITLE
Default to trimja v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ YAML configuration:
 - uses: elliotgoodrich/trimja-action@v1
   with:
     # Version string for trimja.
-    # Default: '1.0.0'
+    # Default: '1.1.0'
     version: ''
 
     # The path to the ninja build file.

--- a/action.yaml
+++ b/action.yaml
@@ -4,7 +4,7 @@ author: 'Elliot Goodrich'
 inputs:
   version:
     description: 'Version of trimja to install'
-    default: '1.0.0'
+    default: '1.1.0'
   path:
     description: 'Path to the ninja build file'
     default: './build.ninja'


### PR DESCRIPTION
This version supports the new build log format found in ninja 1.12.x.