### PR TITLE
Run CI weekly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  schedule:
+    - cron: '0 0 * * SAT'
 
 jobs:
   build:


### PR DESCRIPTION
Run CI weekly so we get a chance to catch any breaking changes.  This commit will cause the CI to run midnight on each Friday.