### PR TITLE
Automatically create major tags (e.g. v1)

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,25 @@
+name: Tag
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  tag:
+    name: Tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          MAJOR="${TAG%%.*}"
+          if [[ ! "$MAJOR" =~ ^v[0-9]+$ ]]; then
+            echo "Error: expected major version like 'v1', got '$MAJOR' (from tag '$TAG')"
+            exit 1
+          fi
+          git tag "$MAJOR" "${{ github.sha }}" --force
+          git push origin "refs/tags/$MAJOR" --force

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,13 +21,13 @@ should not be committed along with the changes.  Once a change has landed on
 
 ## Creating a Release
 
-  1. Create a release from the GitHub website
-     * Select a new tag in the format of `vA.B.C`
-     * Select the `release` branch as the target
-     * Click "Generate release notes"
-     * Keep the generated release name as `vA.B.C`
-     * Click "Publish release"
-  2. `git fetch origin`
-  3. `git tag vA vA.B.C --force`
-  4. `git push origin tag vA --force`
+Create a release from the GitHub website:
+
+  * Select a new tag in the format of `vA.B.C`
+  * Select the `release` branch as the target
+  * Click "Generate release notes"
+  * Keep the generated release name as `vA.B.C`
+  * Click "Publish release"
+
+The CI will automatically tag the same commit as `vA`.
 `


### PR DESCRIPTION
Instead of requiring a manual step to publish the tag for the major version (e.g. `v1`) we do this automatically when a release is published.

This should allow me to further restrict what push access I have to the repo and remove the possibility of manual user error.